### PR TITLE
add ring channels based on presence of lcdMessage in camera details

### DIFF
--- a/bundles/org.openhab.binding.unifiprotect/src/main/java/org/openhab/binding/unifiprotect/internal/UnifiProtectBindingConstants.java
+++ b/bundles/org.openhab.binding.unifiprotect/src/main/java/org/openhab/binding/unifiprotect/internal/UnifiProtectBindingConstants.java
@@ -123,10 +123,10 @@ public class UnifiProtectBindingConstants {
     public static final String CHANNEL_SMART_DETECT_LOITER_SNAPSHOT_LABEL = "Smart Detect Loiter Snapshot";
 
     public static final String CHANNEL_RING = "ring";
-    public static final String CHANNEL_RING_START = "ring-start";
-    public static final String CHANNEL_RING_END = "ring-end";
+    public static final String CHANNEL_RING_LABEL = "Ring";
     public static final String CHANNEL_RING_CONTACT = "ring-contact";
     public static final String CHANNEL_RING_SNAPSHOT = "ring-snapshot";
+    public static final String CHANNEL_RING_SNAPSHOT_LABEL = "Ring Snapshot";
 
     // Light (floodlight)
     public static final String CHANNEL_LIGHT = "light";

--- a/bundles/org.openhab.binding.unifiprotect/src/main/java/org/openhab/binding/unifiprotect/internal/handler/UnifiProtectCameraHandler.java
+++ b/bundles/org.openhab.binding.unifiprotect/src/main/java/org/openhab/binding/unifiprotect/internal/handler/UnifiProtectCameraHandler.java
@@ -562,6 +562,16 @@ public class UnifiProtectCameraHandler extends UnifiProtectAbstractDeviceHandler
                     UnifiProtectBindingConstants.CHANNEL_ACTIVE_PATROL_SLOT, channelAdd, desiredIds);
         }
 
+        if (camera.lcdMessage != null) {
+            addTriggerChannel(UnifiProtectBindingConstants.CHANNEL_RING, UnifiProtectBindingConstants.CHANNEL_RING,
+                    channelAdd, desiredIds, UnifiProtectBindingConstants.CHANNEL_RING_LABEL);
+            addChannel(UnifiProtectBindingConstants.CHANNEL_RING_CONTACT, CoreItemFactory.CONTACT,
+                    UnifiProtectBindingConstants.CHANNEL_RING_CONTACT, channelAdd, desiredIds);
+            addChannel(UnifiProtectBindingConstants.CHANNEL_RING_SNAPSHOT, CoreItemFactory.IMAGE,
+                    UnifiProtectBindingConstants.CHANNEL_SNAPSHOT, channelAdd, desiredIds,
+                    UnifiProtectBindingConstants.CHANNEL_RING_SNAPSHOT_LABEL);
+        }
+
         updateThing(editThing().withChannels(channelAdd).build());
     }
 


### PR DESCRIPTION
AFAICT, this is the only way to identify a doorbell. BUT... a doorbell is the only UniFi camera I have, so can't test to ensure non-doorbells just don't have this key.
