### PR TITLE
Add Cursor Cloud specific development environment instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,3 +169,49 @@ After building, the directory target inside org.openhab.binding.bindingname cont
 | Full build | `mvn clean install` |
 | Build with resolver | `mvn clean install -DwithResolver` |
 | Build a specific binding | `mvn clean install -pl org.openhab.binding.bindingname` |
+
+## Cursor Cloud specific instructions
+
+### Environment
+
+- **Java 21** is pre-installed at `/usr/lib/jvm/java-21-openjdk-amd64`. `JAVA_HOME` is set in `~/.bashrc`.
+- **Maven 3.9.13** is available via the Maven Wrapper (`./mvnw`). There is no system `mvn` on `PATH` — always use `./mvnw` from the repo root.
+- No external services (databases, Docker, message brokers) are required. This is a pure Java/Maven library project.
+
+### Building & testing a specific binding
+
+Always target a specific binding to avoid building all ~500 modules:
+
+```bash
+./mvnw clean install -pl bundles/org.openhab.binding.<name>
+```
+
+The first build resolves the parent POM and dependencies from Maven Central and JFrog; this takes ~3 minutes. Subsequent builds of the same binding are much faster (~10 seconds).
+
+To include upstream module resolution (e.g. `bom/`, `bundles/` reactor POM), add `-am`:
+
+```bash
+./mvnw clean install -pl bundles/org.openhab.binding.<name> -am
+```
+
+Use `-DskipChecks` to skip static analysis during iteration; run full checks before committing.
+
+### Lint
+
+```bash
+./mvnw spotless:check -pl bundles/org.openhab.binding.<name>
+./mvnw spotless:apply -pl bundles/org.openhab.binding.<name>   # auto-fix
+```
+
+Always scope `spotless:apply` to the binding folder — running it at the root takes a very long time.
+
+### Tests
+
+```bash
+./mvnw test -pl bundles/org.openhab.binding.<name>
+```
+
+### Notes
+
+- This repo does **not** produce a runnable application — it produces OSGi bundles consumed by the openhab-core runtime. The "hello world" validation is building a binding, running its tests, and verifying the lint checks pass.
+- The skeleton script for creating new bindings is at `bundles/create_openhab_binding_skeleton.sh`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description

Added Cursor Cloud specific instructions to `AGENTS.md` to enable future cloud agents to quickly set up and use the development environment.

The new section documents:
- Pre-installed Java 21 and Maven Wrapper usage (no system `mvn` on PATH)
- How to build, lint, and test individual bindings efficiently
- Key caveats (always scope to a specific binding, use `./mvnw` not `mvn`)

## Testing

Verified the complete development workflow:

- `./mvnw --version` — Maven 3.9.13 with Java 21
- `./mvnw clean install -pl bundles/org.openhab.binding.astro -am -DskipChecks` — BUILD SUCCESS
- `./mvnw spotless:check -pl bundles/org.openhab.binding.astro` — all files clean
- `./mvnw test -pl bundles/org.openhab.binding.astro` — 173 tests passed, 0 failures

Build and test output log:
[build_and_test_output.log](https://cursor.com/agents/bc-789907b4-6ed2-45be-808f-413b2e5e2b44/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbuild_and_test_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-789907b4-6ed2-45be-808f-413b2e5e2b44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-789907b4-6ed2-45be-808f-413b2e5e2b44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

